### PR TITLE
fix: correct Bonica Brown's bench WR

### DIFF
--- a/Powerlifting/Powerlifting.html
+++ b/Powerlifting/Powerlifting.html
@@ -280,7 +280,7 @@
                     </tr>
                     <tr>
                         <td>84+</td>
-                        <td>132.7</td>
+                        <td>151.5</td>
                         <td>Bonica Brown</td>
                     </tr>
                 </table>


### PR DESCRIPTION
Correct Bonica Brown's bench press world record from her bodyweight at the competition to the value she benched.
